### PR TITLE
Added quartz drawing for dots and an optional success/failed state 

### DIFF
--- a/Source/HUIPatternLockView.swift
+++ b/Source/HUIPatternLockView.swift
@@ -28,126 +28,126 @@ private func ==(lhs: HUIPatternLockViewDot, rhs: HUIPatternLockViewDot) -> Bool 
         case Failed
     }
     
-    static let defaultColor = UIColor(red: 248.00/255.00, green: 200.00/255.00, blue: 79.00/255.00, alpha: 1.0)
-    static let defaultSucceededColor = UIColor.greenColor()
-    static let defaultFailedColor = UIColor.redColor()
+    public static let defaultColor = UIColor(red: 248.00/255.00, green: 200.00/255.00, blue: 79.00/255.00, alpha: 1.0)
+    public static let defaultSucceededColor = UIColor.greenColor()
+    public static let defaultFailedColor = UIColor.redColor()
     
     //MARK: Layouts Related Properties
-    @IBInspectable var numberOfRows: Int = 3 {
+    @IBInspectable public var numberOfRows: Int = 3 {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: true)
         }
     }
-    @IBInspectable var numberOfColumns: Int = 3 {
+    @IBInspectable public var numberOfColumns: Int = 3 {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: true)
         }
     }
-    @IBInspectable var contentInset: UIEdgeInsets = UIEdgeInsetsZero {
+    @IBInspectable public var contentInset: UIEdgeInsets = UIEdgeInsetsZero {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: true)
         }
     }
-    @IBInspectable var dotWidth: CGFloat = 60.00 {
+    @IBInspectable public var dotWidth: CGFloat = 60.00 {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: true)
         }
     }
     
     //MARK: Appearance Related Properties
-    @IBInspectable var lineColor: UIColor = HUIPatternLockView.defaultColor {
+    @IBInspectable public var lineColor: UIColor = HUIPatternLockView.defaultColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var succeededLineColor: UIColor = HUIPatternLockView.defaultSucceededColor {
+    @IBInspectable public var succeededLineColor: UIColor = HUIPatternLockView.defaultSucceededColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var failedLineColor: UIColor = HUIPatternLockView.defaultFailedColor {
+    @IBInspectable public var failedLineColor: UIColor = HUIPatternLockView.defaultFailedColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var lineWidth: CGFloat = 5.00 {
+    @IBInspectable public var lineWidth: CGFloat = 5.00 {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var normalOuterCircleColor: UIColor = UIColor.blackColor() {
+    @IBInspectable public var normalOuterCircleColor: UIColor = UIColor.blackColor() {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var highlightedOuterCircleColor: UIColor = HUIPatternLockView.defaultColor {
+    @IBInspectable public var highlightedOuterCircleColor: UIColor = HUIPatternLockView.defaultColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var succeededOuterCircleColor: UIColor = HUIPatternLockView.defaultSucceededColor {
+    @IBInspectable public var succeededOuterCircleColor: UIColor = HUIPatternLockView.defaultSucceededColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var failedOuterCircleColor: UIColor = HUIPatternLockView.defaultFailedColor {
+    @IBInspectable public var failedOuterCircleColor: UIColor = HUIPatternLockView.defaultFailedColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var normalInnerDotColor: UIColor = UIColor.blackColor() {
+    @IBInspectable public var normalInnerDotColor: UIColor = UIColor.blackColor() {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var highlightedInnerDotColor: UIColor = HUIPatternLockView.defaultColor {
+    @IBInspectable public var highlightedInnerDotColor: UIColor = HUIPatternLockView.defaultColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var succeededInnerDotColor: UIColor = HUIPatternLockView.defaultSucceededColor {
+    @IBInspectable public var succeededInnerDotColor: UIColor = HUIPatternLockView.defaultSucceededColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var failedInnerDotColor: UIColor = HUIPatternLockView.defaultFailedColor {
+    @IBInspectable public var failedInnerDotColor: UIColor = HUIPatternLockView.defaultFailedColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var innerDotRadius: CGFloat = 15.0 {
+    @IBInspectable public var innerDotRadius: CGFloat = 15.0 {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var normalDotImage: UIImage? = nil {
+    @IBInspectable public var normalDotImage: UIImage? = nil {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var highlightedDotImage: UIImage? = nil {
+    @IBInspectable public var highlightedDotImage: UIImage? = nil {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var succeededDotImage: UIImage? = nil {
+    @IBInspectable public var succeededDotImage: UIImage? = nil {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
-    @IBInspectable var failedDotImage: UIImage? = nil {
+    @IBInspectable public var failedDotImage: UIImage? = nil {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
     
-    var password: String?
-    var resetDelay: NSTimeInterval = 1
+    public var password: String?
+    public var resetDelay: NSTimeInterval = 1
     
     
     //MARK: Callback
-    var didDrawPatternWithPassword: ((lockeView: HUIPatternLockView, dotCounts: Int, password: String?) -> Void)? = nil
-    var willResetPatternWithPassword: ((lockeView: HUIPatternLockView, dotCounts: Int, password: String?) -> Void)? = nil
+    public var didDrawPatternWithPassword: ((lockeView: HUIPatternLockView, dotCounts: Int, password: String?) -> Void)? = nil
+    public var willResetPatternWithPassword: ((lockeView: HUIPatternLockView, dotCounts: Int, password: String?) -> Void)? = nil
     
     //MARK: Private Internal vars
     private var normalDots = Array<HUIPatternLockViewDot>()

--- a/Source/HUIPatternLockView.swift
+++ b/Source/HUIPatternLockView.swift
@@ -22,6 +22,7 @@ private func ==(lhs: HUIPatternLockViewDot, rhs: HUIPatternLockViewDot) -> Bool 
 }
 
 @IBDesignable public class HUIPatternLockView : UIView {
+    static let defaultColor = UIColor(red: 248.00/255.00, green: 200.00/255.00, blue: 79.00/255.00, alpha: 1.0)
     
     //MARK: Layouts Related Properties
     @IBInspectable var numberOfRows: Int = 3 {
@@ -46,12 +47,37 @@ private func ==(lhs: HUIPatternLockViewDot, rhs: HUIPatternLockViewDot) -> Bool 
     }
     
     //MARK: Appearance Related Properties
-    @IBInspectable var lineColor: UIColor = UIColor(red: 248.00/255.00, green: 200.00/255.00, blue: 79.00/255.00, alpha: 1.0) {
+    @IBInspectable var lineColor: UIColor = HUIPatternLockView.defaultColor {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
     @IBInspectable var lineWidth: CGFloat = 5.00 {
+        didSet {
+            setLockViewNeedUpdate(needRecalculateDotsFrame: false)
+        }
+    }
+    @IBInspectable var normalOuterCircleColor: UIColor = UIColor.blackColor() {
+        didSet {
+            setLockViewNeedUpdate(needRecalculateDotsFrame: false)
+        }
+    }
+    @IBInspectable var highlightedOuterCircleColor: UIColor = HUIPatternLockView.defaultColor {
+        didSet {
+            setLockViewNeedUpdate(needRecalculateDotsFrame: false)
+        }
+    }
+    @IBInspectable var normalInnerDotColor: UIColor = UIColor.blackColor() {
+        didSet {
+            setLockViewNeedUpdate(needRecalculateDotsFrame: false)
+        }
+    }
+    @IBInspectable var highlightedInnerDotColor: UIColor = HUIPatternLockView.defaultColor {
+        didSet {
+            setLockViewNeedUpdate(needRecalculateDotsFrame: false)
+        }
+    }
+    @IBInspectable var innerDotRadius: CGFloat = 15.0 {
         didSet {
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
@@ -66,6 +92,7 @@ private func ==(lhs: HUIPatternLockViewDot, rhs: HUIPatternLockViewDot) -> Bool 
             setLockViewNeedUpdate(needRecalculateDotsFrame: false)
         }
     }
+    
     
     //MARK: Callback
     var didDrawPatternWithPassword: ((lockeView: HUIPatternLockView, dotCounts: Int, password: String?) -> Void)? = nil
@@ -168,10 +195,19 @@ extension HUIPatternLockView {
             CGContextDrawPath(context, .Stroke)
         }
         
+
         //draw normal dot images
+        CGContextSetLineWidth(context, 1)
+
         if let image = normalDotImage {
             for dot in normalDots {
                 image.drawInRect(dot.frame)
+            }
+        } else {
+            CGContextSetFillColorWithColor(context, normalInnerDotColor.CGColor)
+            CGContextSetStrokeColorWithColor(context, normalOuterCircleColor.CGColor)
+            for dot in normalDots {
+                drawDot(dot)
             }
         }
         
@@ -180,7 +216,23 @@ extension HUIPatternLockView {
             for dot in highlightedDots {
                 image.drawInRect(dot.frame)
             }
+        } else {
+            CGContextSetFillColorWithColor(context, highlightedInnerDotColor.CGColor)
+            CGContextSetStrokeColorWithColor(context, highlightedOuterCircleColor.CGColor)
+            for dot in highlightedDots {
+                drawDot(dot)
+            }
         }
+    }
+
+    private func drawDot(dot: HUIPatternLockViewDot) {
+        let context = UIGraphicsGetCurrentContext()
+        let x = CGRectGetMidX(dot.frame)
+        let y = CGRectGetMidY(dot.frame)
+        CGContextMoveToPoint(context, x, y)
+        CGContextAddArc(context, x, y, innerDotRadius, 0, CGFloat(2*M_PI), 1)
+        CGContextFillPath(context)
+        CGContextStrokeEllipseInRect(context, dot.frame)
     }
 }
 


### PR DESCRIPTION
Hi,

I've added drawing for the dots - there's a couple new `IBInspectable`s, for example `normalOuterCircleColor` and `normalInnerDotColor`. If no images are set for the dots, these are used to draw the dots.

I've also added an optional `password` property. It can be set to a password and the control will then change the color to succeeded/failed before resetting. The delay for this and the colors are also customizable, see `resetDelay`, `succeededOuterCircleColor`, etc.

The code for this isn't very clean, it would probably better to store the state of each dot in `HUIPatternLockViewDot`, instead of having a separate array for each of the states. If I find some time, maybe I'll refactor this at some point and submit another pull request.
